### PR TITLE
Revert a problematic commit

### DIFF
--- a/drivers/tty/serial/msm_geni_serial.c
+++ b/drivers/tty/serial/msm_geni_serial.c
@@ -2513,7 +2513,6 @@ static void msm_geni_serial_set_termios(struct uart_port *uport,
 	int uart_sampling;
 	int clk_freq_diff;
 
-	dev_info(uport->dev, "%s: Start\n", __func__);
 	/* QUP_2.5.0 and older RUMI has sampling rate as 32 */
 	if (port->rumi_platform && port->is_console) {
 		geni_write_reg_nolog(0x21, uport->membase, GENI_SER_M_CLK_CFG);
@@ -2548,7 +2547,6 @@ static void msm_geni_serial_set_termios(struct uart_port *uport,
 	 * Request for nearest possible required frequency instead of the exact
 	 * required frequency.
 	 */
-	dev_info(uport->dev, "%s: geni_se_clk_freq_match\n", __func__);
 	ret = geni_se_clk_freq_match(&port->serial_rsc, desired_rate,
 			&clk_idx, &clk_rate, false);
 	if (ret) {
@@ -2573,7 +2571,6 @@ static void msm_geni_serial_set_termios(struct uart_port *uport,
 	ser_clk_cfg |= (clk_div << CLK_DIV_SHFT);
 
 	/* parity */
-	dev_info(uport->dev, "%s: check parity\n", __func__);
 	tx_trans_cfg = geni_read_reg_nolog(uport->membase,
 							SE_UART_TX_TRANS_CFG);
 	tx_parity_cfg = geni_read_reg_nolog(uport->membase,
@@ -2639,7 +2636,7 @@ static void msm_geni_serial_set_termios(struct uart_port *uport,
 
 	if (likely(baud))
 		uart_update_timeout(uport, termios->c_cflag, baud);
-	dev_info(uport->dev, "%s: geni_serial_write_term_regs\n", __func__);
+
 	geni_serial_write_term_regs(uport, port->loopback, tx_trans_cfg,
 		tx_parity_cfg, rx_trans_cfg, rx_parity_cfg, bits_per_char,
 		stop_bit_len, ser_clk_cfg);
@@ -2661,7 +2658,6 @@ exit_set_termios:
 	msm_geni_serial_start_rx(uport);
 	if (!uart_console(uport))
 		msm_geni_serial_power_off(uport);
-	dev_info(uport->dev, "%s: End\n", __func__);
 	return;
 
 }


### PR DESCRIPTION
Revert "[Revert it!] add more debug messages in msm_geni_serial_set_termios" (commit 1bff15c04f7341f54fc9e8eb00aad4a3a8f620b8).

I've been working on a custom kernel for redbull on A12, and this commit caused a redundant log spam in dmesg which made my tester's device momentarily sluggish.